### PR TITLE
사용자 위치와 가장 가까운 annotation에 접근 시 모달창 띄우고 멀어질 경우 내리기

### DIFF
--- a/PassportTrails.xcodeproj/project.pbxproj
+++ b/PassportTrails.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		388C907C2ACED4790072C3F1 /* PlaceAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388C907B2ACED4790072C3F1 /* PlaceAnnotation.swift */; };
 		388C90882ACEE4D20072C3F1 /* place.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 388C90872ACEE4D20072C3F1 /* place.geojson */; };
 		388C90902AD3F4C70072C3F1 /* MKMapView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */; };
+		38E1C48A2AD54878007EA06F /* HalfHeightModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,6 +41,7 @@
 		388C907B2ACED4790072C3F1 /* PlaceAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceAnnotation.swift; sourceTree = "<group>"; };
 		388C90872ACEE4D20072C3F1 /* place.geojson */ = {isa = PBXFileReference; lastKnownFileType = text; path = place.geojson; sourceTree = "<group>"; };
 		388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+.swift"; sourceTree = "<group>"; };
+		38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfHeightModalViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +137,7 @@
 			children = (
 				388C90642ACD428C0072C3F1 /* PlaceAnnotationView.swift */,
 				388C907B2ACED4790072C3F1 /* PlaceAnnotation.swift */,
+				38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -269,6 +272,7 @@
 				388C907A2ACED16A0072C3F1 /* Place.swift in Sources */,
 				388C90692ACD43930072C3F1 /* StampMapViewController.swift in Sources */,
 				388C90902AD3F4C70072C3F1 /* MKMapView+.swift in Sources */,
+				38E1C48A2AD54878007EA06F /* HalfHeightModalViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PassportTrails.xcodeproj/project.pbxproj
+++ b/PassportTrails.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		388C907C2ACED4790072C3F1 /* PlaceAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388C907B2ACED4790072C3F1 /* PlaceAnnotation.swift */; };
 		388C90882ACEE4D20072C3F1 /* place.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 388C90872ACEE4D20072C3F1 /* place.geojson */; };
 		388C90902AD3F4C70072C3F1 /* MKMapView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */; };
-		38E1C48A2AD54878007EA06F /* HalfHeightModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */; };
+		38E1C48A2AD54878007EA06F /* PlaceArrivalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E1C4892AD54878007EA06F /* PlaceArrivalViewController.swift */; };
 		38E1C48C2AD5730B007EA06F /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E1C48B2AD5730B007EA06F /* UIViewController+.swift */; };
 /* End PBXBuildFile section */
 
@@ -42,7 +42,7 @@
 		388C907B2ACED4790072C3F1 /* PlaceAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceAnnotation.swift; sourceTree = "<group>"; };
 		388C90872ACEE4D20072C3F1 /* place.geojson */ = {isa = PBXFileReference; lastKnownFileType = text; path = place.geojson; sourceTree = "<group>"; };
 		388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+.swift"; sourceTree = "<group>"; };
-		38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfHeightModalViewController.swift; sourceTree = "<group>"; };
+		38E1C4892AD54878007EA06F /* PlaceArrivalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceArrivalViewController.swift; sourceTree = "<group>"; };
 		38E1C48B2AD5730B007EA06F /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -139,7 +139,7 @@
 			children = (
 				388C90642ACD428C0072C3F1 /* PlaceAnnotationView.swift */,
 				388C907B2ACED4790072C3F1 /* PlaceAnnotation.swift */,
-				38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */,
+				38E1C4892AD54878007EA06F /* PlaceArrivalViewController.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -276,7 +276,7 @@
 				388C907A2ACED16A0072C3F1 /* Place.swift in Sources */,
 				388C90692ACD43930072C3F1 /* StampMapViewController.swift in Sources */,
 				388C90902AD3F4C70072C3F1 /* MKMapView+.swift in Sources */,
-				38E1C48A2AD54878007EA06F /* HalfHeightModalViewController.swift in Sources */,
+				38E1C48A2AD54878007EA06F /* PlaceArrivalViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PassportTrails.xcodeproj/project.pbxproj
+++ b/PassportTrails.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		388C90882ACEE4D20072C3F1 /* place.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 388C90872ACEE4D20072C3F1 /* place.geojson */; };
 		388C90902AD3F4C70072C3F1 /* MKMapView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */; };
 		38E1C48A2AD54878007EA06F /* HalfHeightModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */; };
+		38E1C48C2AD5730B007EA06F /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E1C48B2AD5730B007EA06F /* UIViewController+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		388C90872ACEE4D20072C3F1 /* place.geojson */ = {isa = PBXFileReference; lastKnownFileType = text; path = place.geojson; sourceTree = "<group>"; };
 		388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+.swift"; sourceTree = "<group>"; };
 		38E1C4892AD54878007EA06F /* HalfHeightModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalfHeightModalViewController.swift; sourceTree = "<group>"; };
+		38E1C48B2AD5730B007EA06F /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +188,7 @@
 			isa = PBXGroup;
 			children = (
 				388C908F2AD3F4C70072C3F1 /* MKMapView+.swift */,
+				38E1C48B2AD5730B007EA06F /* UIViewController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -264,6 +267,7 @@
 			files = (
 				388C90272AC2D4A10072C3F1 /* Observable.swift in Sources */,
 				388C900E2AC2D3540072C3F1 /* AppDelegate.swift in Sources */,
+				38E1C48C2AD5730B007EA06F /* UIViewController+.swift in Sources */,
 				388C907C2ACED4790072C3F1 /* PlaceAnnotation.swift in Sources */,
 				388C90102AC2D3540072C3F1 /* SceneDelegate.swift in Sources */,
 				388C90652ACD428C0072C3F1 /* PlaceAnnotationView.swift in Sources */,

--- a/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
+++ b/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
@@ -19,7 +19,7 @@ final class StampMapViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        navigationController?.topViewController?.title = "스탬프 지도"
+        navigationController?.navigationBar.isHidden = true
         
         configureLocationManager()
         configureMapView()

--- a/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
+++ b/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
@@ -172,16 +172,7 @@ extension StampMapViewController: MKMapViewDelegate {
         
         if nearestDistance <= 20 {
             mapView.selectAnnotation(nearestAnnotation, animated: true)
-            
-            let vc = HalfHeightModalViewController()
-            if let sheet = vc.sheetPresentationController {
-                sheet.detents = [.custom(identifier: .medium, resolver: { context in
-                    return UIScreen.main.bounds.height * 0.35
-                })]
-                sheet.preferredCornerRadius = 30
-                sheet.largestUndimmedDetentIdentifier = .medium
-            }
-            present(vc, animated: true)
+            presentPlaceArrivalView()
         } else {
             mapView.deselectAnnotation(nearestAnnotation, animated: true)
         }

--- a/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
+++ b/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
@@ -13,6 +13,9 @@ final class StampMapViewController: BaseViewController {
     private let locationManager = CLLocationManager()
     private let mapView = MKMapView()
     
+    private var nearestAnnotation: MKAnnotation?
+    private var isArrivedToPlace = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -165,16 +168,24 @@ extension StampMapViewController: MKMapViewDelegate {
     
     func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
         guard let nearestAnnotation = findNearestAnnotation(userLocation.coordinate) else { return }
+        self.nearestAnnotation = nearestAnnotation
         
         let nearestAnnotationLocation = CLLocation(latitude: nearestAnnotation.coordinate.latitude, longitude: nearestAnnotation.coordinate.longitude)
         let currentUserLocation = CLLocation(latitude: userLocation.coordinate.latitude, longitude: userLocation.coordinate.longitude)
         let nearestDistance = currentUserLocation.distance(from: nearestAnnotationLocation)
         
-        if nearestDistance <= 20 {
+        if nearestDistance <= 20 && isArrivedToPlace == false {
             mapView.selectAnnotation(nearestAnnotation, animated: true)
+            
             presentPlaceArrivalView()
-        } else {
-            mapView.deselectAnnotation(nearestAnnotation, animated: true)
+            isArrivedToPlace = true
+        }
+    }
+    
+    func mapView(_ mapView: MKMapView, didSelect annotation: MKAnnotation) {
+        guard let nearestAnnotation else { return }
+        if isArrivedToPlace == true && annotation === nearestAnnotation {
+            presentPlaceArrivalView()
         }
     }
 }

--- a/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
+++ b/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
@@ -172,6 +172,18 @@ extension StampMapViewController: MKMapViewDelegate {
         
         if nearestDistance <= 20 {
             mapView.selectAnnotation(nearestAnnotation, animated: true)
+            
+            let vc = HalfHeightModalViewController()
+            if let sheet = vc.sheetPresentationController {
+                sheet.detents = [.custom(identifier: .medium, resolver: { context in
+                    return UIScreen.main.bounds.height * 0.35
+                })]
+                sheet.preferredCornerRadius = 30
+                sheet.largestUndimmedDetentIdentifier = .medium
+            }
+            present(vc, animated: true)
+        } else {
+            mapView.deselectAnnotation(nearestAnnotation, animated: true)
         }
     }
 }

--- a/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
+++ b/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
@@ -162,6 +162,18 @@ extension StampMapViewController: MKMapViewDelegate {
             return view
         }
     }
+    
+    func mapView(_ mapView: MKMapView, didUpdate userLocation: MKUserLocation) {
+        guard let nearestAnnotation = findNearestAnnotation(userLocation.coordinate) else { return }
+        
+        let nearestAnnotationLocation = CLLocation(latitude: nearestAnnotation.coordinate.latitude, longitude: nearestAnnotation.coordinate.longitude)
+        let currentUserLocation = CLLocation(latitude: userLocation.coordinate.latitude, longitude: userLocation.coordinate.longitude)
+        let nearestDistance = currentUserLocation.distance(from: nearestAnnotationLocation)
+        
+        if nearestDistance <= 20 {
+            mapView.selectAnnotation(nearestAnnotation, animated: true)
+        }
+    }
 }
 
 //MARK: CLLocationManagerDelegate
@@ -171,9 +183,10 @@ extension StampMapViewController: CLLocationManagerDelegate {
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         if let coordinate = locations.last?.coordinate {
             guard let nearestAnnotation = findNearestAnnotation(coordinate) else { return }
-            self.mapView.selectAnnotation(nearestAnnotation, animated: true)
             
-            let region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 1500, longitudinalMeters: 1500)
+            mapView.selectAnnotation(nearestAnnotation, animated: true)
+            
+            let region = MKCoordinateRegion(center: coordinate, latitudinalMeters: 500, longitudinalMeters: 500)
             mapView.setRegion(region, animated: true)
         }
         locationManager.stopUpdatingLocation()

--- a/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
+++ b/PassportTrails/Scenes/StampMapScene/StampMapViewController.swift
@@ -174,11 +174,14 @@ extension StampMapViewController: MKMapViewDelegate {
         let currentUserLocation = CLLocation(latitude: userLocation.coordinate.latitude, longitude: userLocation.coordinate.longitude)
         let nearestDistance = currentUserLocation.distance(from: nearestAnnotationLocation)
         
-        if nearestDistance <= 20 && isArrivedToPlace == false {
+        if nearestDistance <= 15 && isArrivedToPlace == false {
             mapView.selectAnnotation(nearestAnnotation, animated: true)
-            
             presentPlaceArrivalView()
             isArrivedToPlace = true
+        } else if nearestDistance >= 35 && isArrivedToPlace == true {
+            mapView.deselectAnnotation(nearestAnnotation, animated: true)
+            dismiss(animated: true)
+            isArrivedToPlace = false
         }
     }
     

--- a/PassportTrails/Utils/Custom/HalfHeightModalViewController.swift
+++ b/PassportTrails/Utils/Custom/HalfHeightModalViewController.swift
@@ -1,0 +1,86 @@
+//
+//  HalfHeightModalViewController.swift
+//  PassportTrails
+//
+//  Created by Taekwon Lee on 2023/10/10.
+//
+
+import UIKit
+
+class HalfHeightModalViewController: BaseViewController {
+    
+    private let titleLabel = {
+        let view = UILabel()
+        view.font = .boldSystemFont(ofSize: 30)
+        view.numberOfLines = 1
+        return view
+    }()
+    
+    private let subtitleLabel = {
+        let view = UILabel()
+        view.font = .boldSystemFont(ofSize: 20)
+        view.textColor = .systemBlue
+        view.numberOfLines = 1
+        return view
+    }()
+    
+    private let getButton = {
+        let view = UIButton()
+        view.backgroundColor = .systemBlue
+        view.titleLabel?.font = .boldSystemFont(ofSize: 20)
+        view.setTitleColor(.white, for: .normal)
+        view.layer.masksToBounds = true
+        view.layer.cornerRadius = 20
+        return view
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func configureView() {
+        super.configureView()
+        
+        view.backgroundColor = .white
+        
+        titleLabel.text = "🎉 장소에 도착했습니다 🎉"
+        
+        subtitleLabel.text = "아래 버튼을 눌러 스탬프를 받으세요 👇"
+        
+        getButton.setTitle("스탬프 받기", for: .normal)
+    }
+    
+    override func configureHierarchy() {
+        super.configureHierarchy()
+        
+        view.addSubview(titleLabel)
+        view.addSubview(subtitleLabel)
+        view.addSubview(getButton)
+    }
+    
+    override func setConstraints() {
+        super.setConstraints()
+        
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+            titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        ])
+        
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            subtitleLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            subtitleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        ])
+        
+        getButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            getButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20),
+            getButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            getButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            getButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            getButton.heightAnchor.constraint(equalToConstant: 60)
+        ])
+    }
+}

--- a/PassportTrails/Utils/Custom/PlaceArrivalViewController.swift
+++ b/PassportTrails/Utils/Custom/PlaceArrivalViewController.swift
@@ -1,5 +1,5 @@
 //
-//  HalfHeightModalViewController.swift
+//  PlaceArrivalViewController.swift
 //  PassportTrails
 //
 //  Created by Taekwon Lee on 2023/10/10.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class HalfHeightModalViewController: BaseViewController {
+class PlaceArrivalViewController: BaseViewController {
     
     private let titleLabel = {
         let view = UILabel()

--- a/PassportTrails/Utils/Extension/UIViewController+.swift
+++ b/PassportTrails/Utils/Extension/UIViewController+.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UIViewController {
     func presentPlaceArrivalView() {
-        let vc = HalfHeightModalViewController()
+        let vc = PlaceArrivalViewController()
         if let sheet = vc.sheetPresentationController {
             sheet.detents = [.custom(identifier: .medium, resolver: { context in
                 return UIScreen.main.bounds.height * 0.35

--- a/PassportTrails/Utils/Extension/UIViewController+.swift
+++ b/PassportTrails/Utils/Extension/UIViewController+.swift
@@ -14,8 +14,10 @@ extension UIViewController {
             sheet.detents = [.custom(identifier: .medium, resolver: { context in
                 return UIScreen.main.bounds.height * 0.35
             })]
+            
+            sheet.prefersGrabberVisible = true
             sheet.preferredCornerRadius = 30
-            sheet.largestUndimmedDetentIdentifier = .medium
+            sheet.largestUndimmedDetentIdentifier = .large
         }
         present(vc, animated: true)
     }

--- a/PassportTrails/Utils/Extension/UIViewController+.swift
+++ b/PassportTrails/Utils/Extension/UIViewController+.swift
@@ -1,0 +1,22 @@
+//
+//  UIViewController+.swift
+//  PassportTrails
+//
+//  Created by Taekwon Lee on 2023/10/10.
+//
+
+import UIKit
+
+extension UIViewController {
+    func presentPlaceArrivalView() {
+        let vc = HalfHeightModalViewController()
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.custom(identifier: .medium, resolver: { context in
+                return UIScreen.main.bounds.height * 0.35
+            })]
+            sheet.preferredCornerRadius = 30
+            sheet.largestUndimmedDetentIdentifier = .medium
+        }
+        present(vc, animated: true)
+    }
+}


### PR DESCRIPTION
## 💡 이슈 번호
- [x] https://github.com/andy-archive/PassportTrails/issues/12
## ✅ 체크리스트 
- [x] merge 하려는 branch가 정확한지 확인
- [x] Reviewers 및 Labels 설정
- [x] PR과 관련없는 commit이 없는지 확인
- [x] 코드 컨벤션 준수
- [x] 커밋 컨벤션 준수
- [x] 커밋 세분화
- [ ] 코드를 검증하는 테스트 추가
- [ ] 관련 기존 테스트 통과 여부 확인
## 🧭 작업 유형
- [x] 새로운 기능 추가 ⚡️
- [ ] 버그 발생 🐛
- [x] 버그 수정 🛠️
- [ ] 문서 수정 📝
- [ ] 리팩토링 ♻️
- [ ] 테스트 코드 추가 🧪
- [ ] 빌드 업무 수정 또는 패키지 매니저 수정 📦
## ✍️ 작업 내용
- [x] 사용자 위치와 가장 가까운 Annoation에 15m 이하 접근할 시 해당 Annotation을 선택 및 모달창 띄우기
- [x] 사용자 위치와 가장 가까운 Annoation에 35m 이상 멀어지면 해당 Annotation을 선택 해제 및 모달창 내리기
- [x] 사용자가 모달창을 일부러 내릴 경우 annotation을 다시 선택하지 않는 이상 자동으로 모달창을 띄우지 않도록 구현
- [x] Custom 모달창을 Extension으로 분리
- [x] 사용자가 지도에 더 집중할 수 있도록 navigation bar을 숨김 처리

|현 위치와 가까워질 때|현 위치와 멀어질 때|
|:-:|:-:|
|<img src="https://github.com/andy-archive/PassportTrails/assets/102043891/dd552644-ad50-4f98-8192-25fb2e9b7423" alt="annotation 접근 시" width="200">|<img src="https://github.com/andy-archive/PassportTrails/assets/102043891/d89ab7d4-26ae-4622-93d6-116235566006" alt="annotation 접근 시" width="200">|


## 🔥 특이 사항
### 모달창을 내려도 무한히 함수를 호출하여 모달창을 계속 띄우는 문제 수정
- 거리가 인접했을 때의 로직만을 구현하면 아래와 같이 사용자의 위치가 변할 때마다 무한히 함수가 호출이 됩니다.
- 따라서 거리가 멀어진 경우에도 로직을 구현하여 이를 방지했습니다.

|현 위치와 가까우면 계속 함수 호출|
|:-:|
|![#13 모달창을 내려도 무한히 함수를 호출하여 모달창을 계속 띄우는 문제 수정](https://github.com/andy-archive/PassportTrails/assets/102043891/d4c67c25-7e1d-4604-b01e-6a8e6edd913d)|

